### PR TITLE
Make custom data possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ appium-event-parser
 
 This is a simple CLI script to parse Appium event timings. What are event timings? When you pass the capability `eventTimings` with the value `true` to an Appium session, then when calling the get session capabilities command in your client (`GET /session/:id`) you will have an `events` key in the response object. This key contains information about Appium-internal events and when they occurred. This information is useful for profiling Appium or debugging Appium, and is not generally useful for users.
 
+Any custom data added to the event timing JSON (for instance, to identify a build) can be marked with a property `iterate` set to `false`.
+
 ## Installation
 
 ```

--- a/timeline.js
+++ b/timeline.js
@@ -13,7 +13,7 @@ function timeline (data) {
   //   ["eventName", timestamp2],
   //   ["eventName2", timestamp3]
   // ]
-  for (let eventType of Object.keys(data).filter(k => k !== 'commands')) {
+  for (let eventType of Object.keys(data).filter(k => k !== 'commands' && data[k].iterate !== false)) {
     for (let eventTime of data[eventType]) {
       absTimeline.push([eventType, eventTime]);
     }


### PR DESCRIPTION
I want to be able to put other information into the JSON to identify things. Right now for testing I'm adding the time that the session started, and the SHA of the commit that is triggering the build.

In order to not lock someone into one thing, I've added a property `iterate` that is `false` to the custom part, so that it is ignored when parsing.